### PR TITLE
キーボード と マウス の入力にも対応する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGES
 
+## Version 1.1.0
+- キーボード と マウス の入力にも対応
+- gamepad_init の仕様を変更 (破壊的変更)
+  - before: `void* gamepad_init();`
+  - after: `void* gamepad_init(int useGamePad, int useKeybord, int useMouse);`
+
 ## Version 1.0.0
 - first version
 - 以降, 更新は Pull Request でおこないます

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gamepad-osx
-- mac OS (osx) 用のプログラムで IOKit (HID) を用いて gamepad / joystick を使えるようにするライブラリです
+- mac OS (osx) 用のゲームプログラムで IOKit (HID) を用いて gamepad / joystick / keybord の入力を検出するライブラリです
 - GameController framework と違い, 様々な種類の ゲームパッド を認識できます
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gamepad-osx
-- mac OS (osx) 用のゲームプログラムで IOKit (HID) を用いて gamepad / joystick / keybord の入力を検出するライブラリです
+- mac OS (osx) 用のゲームプログラムで IOKit (HID) を用いて gamepad / joystick / keybord / mouse の入力を検出するライブラリです
 - GameController framework と違い, 様々な種類の ゲームパッド を認識できます
 
 ## License
@@ -16,15 +16,18 @@
 ## API specification
 ### initialize
 ```c
-void* gamepad_init();
+void* gamepad_init(int useGamePad, int useKeybord, int useMouse)
 ```
-gamepad の device context を返す (失敗時は `NULL` を返す)
+- gamepad の device context を返す (失敗時は `NULL` を返す)
+- `useGamePad` は 非0 で ゲームパッド/ジョイステック を使用し 0 なら使用しない
+- `useKeybord` は 非0 で キーボード を使用し 0 なら使用しない
+- `useMouse` は 非0 で マウス/トラックパッド を使用し 0 なら使用しない
 
 ### set callback
 ```c
 void gamepad_set_callback(void* ctx, void (*callback)(int type, int page, int usage, int value));
 ```
-- gamepad の入力コールバックを設定
+- gamepad, keybord, mouse の入力コールバックを設定
 - type, page, usage, value の値を参照することで入力状態を確認できる
 
 _参考: ELECOM の JC-U3312S シリーズでテストした結果_

--- a/gamepad.c
+++ b/gamepad.c
@@ -126,6 +126,7 @@ void* gamepad_init()
     }
     append_matching_dictionary(matcher, kHIDPage_GenericDesktop, kHIDUsage_GD_Joystick);
     append_matching_dictionary(matcher, kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad);
+    append_matching_dictionary(matcher, kHIDPage_GenericDesktop, kHIDUsage_GD_Keyboard);
     IOHIDManagerSetDeviceMatchingMultiple(c->hid_manager, matcher);
     CFRelease(matcher);
 

--- a/gamepad.c
+++ b/gamepad.c
@@ -31,15 +31,13 @@ static void append_matching_dictionary(CFMutableArrayRef matcher, uint32_t page,
     CFRelease(result);
 }
 
-static void device_input(void* ctx, IOReturn result, void* sender, IOHIDValueRef val)
+static void device_input(void* ctx, IOReturn result, void* sender, IOHIDValueRef value)
 {
     struct gamepad_context* c = (struct gamepad_context*)ctx;
-    IOHIDElementRef element = IOHIDValueGetElement(val);
-    int type = IOHIDElementGetType(element);
-    int page = IOHIDElementGetUsagePage(element);
-    int usage = IOHIDElementGetUsage(element);
-    int value = IOHIDValueGetIntegerValue(val);
-    if (c->callback) c->callback(type, page, usage, value);
+    if (c->callback) {
+        IOHIDElementRef element = IOHIDValueGetElement(value);
+        c->callback(IOHIDElementGetType(element), IOHIDElementGetUsagePage(element), IOHIDElementGetUsage(element), IOHIDValueGetIntegerValue(value));
+    }
 }
 
 static void device_attached(void* ctx, IOReturn result, void* sender, IOHIDDeviceRef device)
@@ -104,7 +102,7 @@ static void device_detached(void* ctx, IOReturn result, void* sender, IOHIDDevic
     }
 }
 
-void* gamepad_init()
+void* gamepad_init(int useGamePad, int useKeybord, int useMouse)
 {
     struct gamepad_context* c;
     CFMutableArrayRef matcher;
@@ -124,9 +122,16 @@ void* gamepad_init()
         gamepad_term(c);
         return NULL;
     }
-    append_matching_dictionary(matcher, kHIDPage_GenericDesktop, kHIDUsage_GD_Joystick);
-    append_matching_dictionary(matcher, kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad);
-    append_matching_dictionary(matcher, kHIDPage_GenericDesktop, kHIDUsage_GD_Keyboard);
+    if (useGamePad) {
+        append_matching_dictionary(matcher, kHIDPage_GenericDesktop, kHIDUsage_GD_Joystick);
+        append_matching_dictionary(matcher, kHIDPage_GenericDesktop, kHIDUsage_GD_GamePad);
+    }
+    if (useKeybord) {
+        append_matching_dictionary(matcher, kHIDPage_GenericDesktop, kHIDUsage_GD_Keyboard);
+    }
+    if (useMouse) {
+        append_matching_dictionary(matcher, kHIDPage_GenericDesktop, kHIDUsage_GD_Mouse);
+    }
     IOHIDManagerSetDeviceMatchingMultiple(c->hid_manager, matcher);
     CFRelease(matcher);
 

--- a/gamepad.h
+++ b/gamepad.h
@@ -2,7 +2,7 @@
 extern "C" {
 #endif
 
-void* gamepad_init();
+void* gamepad_init(int useGamePad, int useKeybord, int useMouse);
 void gamepad_set_callback(void* ctx, void (*callback)(int type, int page, int usage, int value));
 void gamepad_term(void* ctx);
 

--- a/test.c
+++ b/test.c
@@ -6,6 +6,11 @@
 static void callback(int type, int page, int usage, int value)
 {
     printf("type=%d, page=%d, usage=%d, value=%d\n", type, page, usage, value);
+
+    /* end main loop if push esc key */
+    if (2 == type && 7 == page && 41 == usage && 0 == value) {
+        CFRunLoopStop(CFRunLoopGetCurrent());
+    }
 }
 
 int main()

--- a/test.c
+++ b/test.c
@@ -16,11 +16,9 @@ static void callback(int type, int page, int usage, int value)
 int main()
 {
     void* ctx;
-    char buf[80];
-    int i;
 
     /* initialize gamepad */
-    ctx = gamepad_init();
+    ctx = gamepad_init(1, 1, 0);
     if (!ctx) {
         puts("init failed");
         return -1;


### PR DESCRIPTION
- キーボード と マウス の入力にも対応
- gamepad_init の仕様を変更 (破壊的変更)
  - before: `void* gamepad_init();`
  - after: `void* gamepad_init(int useGamePad, int useKeybord, int useMouse);`
- see also: https://github.com/suzukiplan/gamepad-osx/issues/4
