### PR TITLE
V1.1.3

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # CHANGES
 
+## Version 1.1.3
+- gamepad_set_callback の第1引数(ctx) に NULL を指定できるようにする
+
+## Version 1.1.2
+- README.md の改定のみ
+
 ## Version 1.1.1
 - XCode でビルドした時に警告が出ないようにする
 

--- a/gamepad.c
+++ b/gamepad.c
@@ -144,6 +144,7 @@ void* gamepad_init(int useGamePad, int useKeybord, int useMouse)
 void gamepad_set_callback(void* ctx, void (*callback)(int type, int page, int usage, int value))
 {
     struct gamepad_context* c = (struct gamepad_context*)ctx;
+    if (!c) return;
     c->callback = callback;
 }
 


### PR DESCRIPTION
`gamepad_set_callback` で `ctx` に `NULL` を指定できるようにする。
これにより、利用側のプログラムでは `gamepad_init` の `NULL` チェックを省略することができる。
ゲームパッド自体、オプショナルなものだからそうしておくべきかなと。
